### PR TITLE
Update the example command line in the README to include "python"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requires: PostgreSQL 9.0 or later
 Usage example:
 
 ::
-    flexible_freeze.py -m 120 --dblist="prod,queue" --pause 5 -U postgres
+    python flexible_freeze.py -m 120 --dblist="prod,queue" --pause 5 -U postgres
 
 Arguments:
 


### PR DESCRIPTION
Since we don't include a `#!/usr/bin/python` shebang at the
top of the script, we add `python` to the beginning of the
example command line.

Resolves #18 
